### PR TITLE
Default to monaco editor for V3

### DIFF
--- a/lib/commands/init/index.js
+++ b/lib/commands/init/index.js
@@ -265,8 +265,8 @@ async function promptEditorSettings() {
             type: 'select',
             name: 'codeEditor',
             message: 'Select the text editor component to use in the Node-RED Editor',
-            initial: 'ace',
-            choices: [ {name:"ace (default)", value:"ace"}, {name:"monaco (new for 2.0)", value:"monaco"}],
+            initial: 'monaco',
+            choices: [ {name:"monaco (default)", value:"monaco"}, {name:"ace", value:"ace"} ],
             result(value) {
                 return this.find(value).value;
             }

--- a/lib/commands/init/resources/settings.js.mustache
+++ b/lib/commands/init/resources/settings.js.mustache
@@ -351,7 +351,7 @@ module.exports = {
         },
         codeEditor: {
             /** Select the text editor component used by the editor.
-             * Defaults to "ace", but can be set to "ace" or "monaco"
+             * As of Node-RED V3, this defaults to "monaco", but can be set to "ace" if desired
              */
             lib: "{{codeEditor}}",
             options: {
@@ -363,7 +363,7 @@ module.exports = {
                  */
                 theme: "vs",
                 /** other overrides can be set e.g. fontSize, fontFamily, fontLigatures etc.
-                 * for the full list, see https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.istandaloneeditorconstructionoptions.html
+                 * for the full list, see https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.IStandaloneEditorConstructionOptions.html
                  */
                 //fontSize: 14,
                 //fontFamily: "Cascadia Code, Fira Code, Consolas, 'Courier New', monospace",


### PR DESCRIPTION
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)


## Proposed changes

Align with changes in node-red v3 where monaco is the default code editor
Related changes: [Set monaco as default code editor as of v3.x #3543](https://github.com/node-red/node-red/pull/3543)

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
