### PR TITLE
Add new themes introduced in @node-red-contrib-themes/theme-collection v3.0

### DIFF
--- a/lib/commands/init/index.js
+++ b/lib/commands/init/index.js
@@ -259,7 +259,7 @@ async function promptEditorSettings() {
             name: 'theme',
             message: 'Select a theme for the editor. To use any theme other than "default", you will need to install @node-red-contrib-themes/theme-collection in your Node-RED user directory.',
             initial: 'default',
-            choices: [ "default", "dark", "dracula", "midnight-red", "oled", "solarized-dark", "solarized-light"],
+            choices: [ "default", "aurora", "cobalt2", "dark", "dracula", "espresso-libre", "midnight-red", "monoindustrial", "monokai", "oceanic-next", "oled", "solarized-dark", "solarized-light", "tokyo-night", "zenburn"],
         },
         {
             type: 'select',


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

Node-RED Contrib Theme Collection version 3.0 introduced new themes:

- aurora
- cobalt2
- espresso-libre
- monoindustrial
- monokai
- oceanic-next
- tokyo-night
- zenburn

This PR adds them as options.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
