### PR TITLE
Update template settings for 3.1

### DIFF
--- a/lib/commands/init/resources/settings.js.mustache
+++ b/lib/commands/init/resources/settings.js.mustache
@@ -395,6 +395,7 @@ module.exports = {
  *  - fileWorkingDirectory
  *  - functionGlobalContext
  *  - functionExternalModules
+ *  - functionTimeout
  *  - nodeMessageBufferMaxLength
  *  - ui (for use with Node-RED Dashboard)
  *  - debugUseColors
@@ -418,6 +419,9 @@ module.exports = {
 
     /** Allow the Function node to load additional npm modules directly */
     functionExternalModules: {{functionExternalModules}},
+
+    /** Default timeout, in seconds, for the Function node. 0 means no timeout is applied */
+    functionTimeout: 0,
 
     /** The following property can be used to set predefined values in Global Context.
      * This allows extra node modules to be made available with in Function node.


### PR DESCRIPTION
Syncs the template settings with those in 3.1 - adding `functionTimeout`