### PR TITLE
let uiHost be set by security question in admin init. Beef up language around security question.

### DIFF
--- a/lib/commands/init/index.js
+++ b/lib/commands/init/index.js
@@ -135,7 +135,7 @@ async function promptSecurity() {
             type: 'select',
             name: 'adminAuth',
             initial: "Yes",
-            message: 'Do you want to setup user security?',
+            message: 'Do you want to setup user security?\n  DO NOT select No if you will expose Node-RED to the internet - or you will be hacked!',
             choices: ['Yes', 'No'],
             result(value) {
                 return value === "Yes"
@@ -160,6 +160,10 @@ async function promptSecurity() {
                 break;
             }
         }
+        responses.uiHost = '//uiHost: "0.0.0.0",'
+    }
+    else {
+        responses.uiHost = 'uiHost: "127.0.0.1",'
     }
     return responses;
 }
@@ -287,6 +291,7 @@ async function command(argv, result) {
         };
         config.adminAuth = JSON.stringify(adminAuth,"",4).replace(/\n/g,"\n    ");
     }
+    config.uiHost = securityResponses.uiHost;
 
     const projectsResponses = await promptProjects();
     let flowFileSettings = {};

--- a/lib/commands/init/resources/settings.js.mustache
+++ b/lib/commands/init/resources/settings.js.mustache
@@ -151,7 +151,7 @@ module.exports = {
      * The following property can be used to listen on a specific interface. For
      * example, the following would only allow connections from the local machine.
      */
-    //uiHost: "127.0.0.1",
+    {{uiHost}},
 
     /** The maximum size of HTTP request that will be accepted by the runtime api.
      * Default: 5mb
@@ -222,17 +222,17 @@ module.exports = {
     /** When httpAdminRoot is used to move the UI to a different root path, the
      * following property can be used to identify a directory of static content
      * that should be served at http://localhost:1880/.
-     * When httpStaticRoot is set differently to httpAdminRoot, there is no need 
+     * When httpStaticRoot is set differently to httpAdminRoot, there is no need
      * to move httpAdminRoot
      */
     //httpStatic: '/home/nol/node-red-static/', //single static source
     /* OR multiple static sources can be created using an array of objects... */
     //httpStatic: [
-    //    {path: '/home/nol/pics/',    root: "/img/"}, 
-    //    {path: '/home/nol/reports/', root: "/doc/"}, 
+    //    {path: '/home/nol/pics/',    root: "/img/"},
+    //    {path: '/home/nol/reports/', root: "/doc/"},
     //],
 
-    /**  
+    /**
      * All static routes will be appended to httpStaticRoot
      * e.g. if httpStatic = "/home/nol/docs" and  httpStaticRoot = "/static/"
      *      then "/home/nol/docs" will be served at "/static/"


### PR DESCRIPTION
(force to 127.0.0.1 if no admin password)

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

This change beefs up the language about choosing a password... ie by adding
"  DO NOT select No if you will expose Node-RED to the internet - or you will be hacked!"

If the user then still selects no it then changes the uiHost setting to be 127.0.0.1 so that only the local browser can connect and edit by default

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
