### PR TITLE
fix: replace deprecated function `isArray`

### DIFF
--- a/lib/result.js
+++ b/lib/result.js
@@ -58,7 +58,7 @@ function logNodeSet(node) {
         console.log(JSON.stringify(node,' ',4));
         return;
     }
-    if (util.isArray(node)) {
+    if (Array.isArray(node)) {
         if (node.length > 0) {
             node = node[0];
         }
@@ -79,7 +79,7 @@ function logNodeList(nodes) {
         console.log(JSON.stringify(nodes,' ',4));
         return;
     }
-    if (!util.isArray(nodes)) {
+    if (!Array.isArray(nodes)) {
         nodes = [nodes];
     }
     nodes.sort(function(n1,n2) {


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

Replace deprecated function `isArray`.

```js
util.isArray([]);
```

> Deprecated: Use [Array.isArray()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray) instead.

Source: https://nodejs.org/docs/latest-v18.x/api/util.html#utilisarrayobject

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
