### PR TITLE
change help text to match embedded usage

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -34,7 +34,7 @@ var commands = {
 
 function help() {
     var helpText = "Usage:" + "\n" +
-        "   node-red-admin <command> [args] [--help] [--userDir DIR] [--json]\n\n" +
+        "   node-red admin <command> [args] [--help] [--userDir DIR] [--json]\n\n" +
         "Description:" + "\n" +
         "   Node-RED command-line client\n\n" +
         "Commands:\n" +

--- a/lib/result.js
+++ b/lib/result.js
@@ -195,7 +195,7 @@ module.exports = {
     },
     help: function(command) {
         var helpText = "Usage:" + "\n" +
-            "   node-red-admin " + command.usage + "\n\n" +
+            "   node-red admin " + command.usage + "\n\n" +
             "Description:" + "\n" +
             "   " + command.description + "\n\n" +
             "Options:" + "\n" +


### PR DESCRIPTION
now that that is the default

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
As we now build in the admin feature the help text should reflect that more than the old cli usage - so should say   node-red admin   rather than node-red-admin.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
