### PR TITLE
Add usage telemetry question to admin init command

### DIFF
--- a/lib/commands/init/index.js
+++ b/lib/commands/init/index.js
@@ -94,6 +94,27 @@ async function promptSettingsFile(opts) {
     return responses;
 }
 
+async function promptTelemetry() {
+    heading("Share Anonymouse Usage Information");
+
+    const responses = await prompt([
+        {
+            type: 'select',
+            name: 'telemetryEnabled',
+            // initial: "Yes",
+            message: `Node-RED would like to send anonymous usage data back to the Node-RED team.
+This information helps us to understand how it is used.
+For full information on what information is collected and how it is used,
+please see https://nodered.org/docs/telemetry`,
+            choices: ['Yes, send my usage data', 'No, do not send my usage data'],
+            result(value) {
+                return /Yes/.test(value)
+            }
+        }
+    ])
+    return responses
+}
+
 async function promptUser() {
     const responses = await prompt([
         {
@@ -278,6 +299,9 @@ async function command(argv, result) {
     const userDir = argv["u"] || argv["userDir"] || path.join(process.env.HOME || process.env.USERPROFILE || process.env.HOMEPATH || process.env.NODE_RED_HOME,".node-red");
 
     const fileSettings = await promptSettingsFile({userDir});
+
+    const telemetryResponses = await promptTelemetry()
+    config.telemetryEnabled = telemetryResponses.telemetryEnabled ? 'true' : 'false'
 
     const securityResponses = await promptSecurity();
     if (securityResponses.adminAuth) {

--- a/lib/commands/init/resources/settings.js.mustache
+++ b/lib/commands/init/resources/settings.js.mustache
@@ -276,6 +276,7 @@ module.exports = {
  * Runtime Settings
  *  - lang
  *  - runtimeState
+ *  - telemetry
  *  - diagnostics
  *  - logging
  *  - contextStorage
@@ -313,6 +314,23 @@ module.exports = {
         enabled: false,
         /** show or hide runtime stop/start options in the node-red editor. Must be set to `false` to hide */
         ui: false,
+    },
+    telemetry: {
+        /** 
+         * By default, telemetry is disabled until the user provides consent the first
+         * time they open the editor.
+         * 
+         * The following property can be uncommented and set to true/false to enable/disable
+         * telemetry without seeking further consent in the editor.
+         * The user can override this setting via the user settings dialog within the editor
+         */
+        {{^telemetryEnabled}}//enabled: true,{{/telemetryEnabled}}
+        {{#telemetryEnabled}}enabled: {{telemetryEnabled}},{{/telemetryEnabled}}
+        /**
+         * If telemetry is enabled, the editor will notify the user if a new version of Node-RED
+         * is available. Set the following property to false to disable this notification.
+         */
+        // updateNotification: true
     },
      /** Configure the logging output */
      logging: {


### PR DESCRIPTION
Adds a question on enabling usage telemetry to the `init` command:

<img width="563" alt="image" src="https://github.com/user-attachments/assets/96037991-9c93-433f-8f92-557c85f8dc19" />

The wording matches that used in https://github.com/node-red/node-red/pull/5117 - will want to keep them consistent.