### PR TITLE
Update axios dependency (fixes GHSA-43fc-jf86-j433)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     },
     "dependencies": {
         "ansi-colors": "^4.1.3",
-        "axios": "1.12.2",
+        "axios": "^1.13.5",
         "bcryptjs": "3.0.2",
         "cli-table": "^0.3.11",
         "enquirer": "^2.3.6",


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Updating this package fixes security issue [GHSA-43fc-jf86-j433](https://github.com/advisories/GHSA-43fc-jf86-j433)/CVE-2026-25639.

From my reading of https://github.com/axios/axios/blob/v1.x/CHANGELOG.md and https://github.com/axios/axios/releases the main new feature of version 1.13 is support for HTTP2 and no breaking changes, so stepping up should not represent a problem.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
