### PR TITLE
Update axios dependency (fixes GHSA-3p68-rc4w-qgx5)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "ansi-colors": "4.1.3",
-                "axios": "1.14.0",
+                "axios": "1.15.0",
                 "bcryptjs": "3.0.3",
                 "cli-table": "0.3.11",
                 "enquirer": "2.4.1",
@@ -955,9 +955,9 @@
             "license": "MIT"
         },
         "node_modules/axios": {
-            "version": "1.14.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
-            "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+            "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
             "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.15.11",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     },
     "dependencies": {
         "ansi-colors": "4.1.3",
-        "axios": "1.14.0",
+        "axios": "1.15.0",
         "bcryptjs": "3.0.3",
         "cli-table": "0.3.11",
         "enquirer": "2.4.1",


### PR DESCRIPTION
The only kind of potential breaking issue mentioned in the [release note](https://github.com/axios/axios/releases/tag/v1.15.0) was deprecation of `url.parse` which I did not find any usage of here.

All tests still pass after updating.